### PR TITLE
Fix bug caused by blueprint with pages.sort but without pages.template

### DIFF
--- a/core/blueprint.php
+++ b/core/blueprint.php
@@ -63,6 +63,8 @@ abstract class BlueprintAbstract {
             $settings->template[] = static::find($t);
           }
         }
+      } else {
+        $settings->template = static::all();
       }
 
       if(isset($pages['sortable']) and $pages['sortable'] == false) {


### PR DESCRIPTION
This PR fixes a problem, when adding `pags.sort: flip` would cause the “add subpage” modal to break.

```
pages: true/false
```

-> worked

```
pages:
  sort: flip
```

-> broke the “add subpage” view

A workarounds was to specify the template explicitly:

```
pages:
  sort: flip
  template: foo
```

-> worked

```
pages:
  sort: flip
  template:
       - foo
       - bar
```

-> worked

---

With this PR, the `template` setting defaults to all templates, when using `sort`.

---

There is a conceptual problem remaining: 
What to do when the user intends to flip the sorting of the pages, but wants disable creation of sub pages at the same time?
