### PR TITLE
Fix #45: support escaping of ')' and ':' in kirby tags with backslash

### DIFF
--- a/core/kirbytag.php
+++ b/core/kirbytag.php
@@ -47,7 +47,7 @@ abstract class KirbytagAbstract {
         if(!isset($search[$num+1])) break;
 
         $key   = trim($search[$num]);
-        $value = trim($search[$num+1]);
+        $value = trim(preg_replace('!\\\\(.)!', '$1', $search[$num+1]));
 
         $this->attr[$key] = $value;
         $num = $num+2;

--- a/core/kirbytext.php
+++ b/core/kirbytext.php
@@ -46,7 +46,7 @@ abstract class KirbytextAbstract {
     }
 
     // tags
-    $val = preg_replace_callback('!(?=[^\]])\([a-z0-9]+:.*?\)!i', array($this, 'tag'), $val);
+    $val = preg_replace_callback('!(?=[^\]])\(([a-z0-9]+:(?:\\\\\)|[^\)])*?)\)!i', array($this, 'tag'), $val);
 
     // markdownify
     $val = markdown($val);
@@ -62,8 +62,7 @@ abstract class KirbytextAbstract {
 
   public function tag($input) {
 
-    // remove the brackets
-    $tag  = trim(rtrim(ltrim($input[0], '('), ')'));
+    $tag  = trim($input[1]);
     $name = trim(substr($tag, 0, strpos($tag, ':')));
 
     // if the tag is not installed return the entire string


### PR DESCRIPTION
E.g.:

(link: http://github.com/ text: (#\))

(link: http://github.com/ text: some (text\) in (\) title: The Title)

(link: http://github.com/ text: some (text\) in (\) and title\: in text title: The Title)
