### PR TITLE
Encode filenames in URL's to allow special characters.

### DIFF
--- a/core/file.php
+++ b/core/file.php
@@ -111,7 +111,7 @@ abstract class FileAbstract extends Media {
    * @return string
    */
   public function url() {
-    return kirby::instance()->urls()->content() . '/' . $this->page->diruri() . '/' . $this->filename;
+    return kirby::instance()->urls()->content() . '/' . $this->page->diruri() . '/' . urlencode($this->filename);
   }
 
   /**


### PR DESCRIPTION
While playing with the file browser in the panel I noticed some images from my phone had ( ) brackets in the URL's and the panel wouldn't show them. These should be encoded before being sent so I just wrapped the filename in a urlencode() call. Up to you if you want to fix it this way or if you have a better solution.
