### PR TITLE
Add public method get_all_attributes()

### DIFF
--- a/core/kirbytag.php
+++ b/core/kirbytag.php
@@ -146,5 +146,9 @@ abstract class KirbytagAbstract {
   public function __toString() {
     return (string)$this->html();
   }
+  
+  public function get_all_attributes() {
+    return  $this->attr;
+  }
 
 }


### PR DESCRIPTION
Added a public method cause sometimes you may want to get the array containing all the attributtes.
