### PR TITLE
New version of parsedown and parsedown extra, fixing new line bug

### DIFF
--- a/vendors/parsedown.php
+++ b/vendors/parsedown.php
@@ -687,6 +687,13 @@ class Parsedown
             }
         }
 
+        if (isset($Block['interrupted']))
+        {
+            $Block['element'] .= "\n";
+
+            unset($Block['interrupted']);
+        }
+
         $Block['element'] .= "\n".$Line['body'];
 
         return $Block;


### PR DESCRIPTION
Fixing the issue that paragraphs within a markdown-extra div are not rendered correctly.
