### PR TITLE
Fix UID being returned as string when no title set.

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -665,7 +665,15 @@ abstract class PageAbstract {
    */
   public function title() {
     $title = $this->content()->get('title');
-    return $title != '' ? $title : $this->uid();
+    
+    if ($title == '') {
+      $title = new Field();
+      $title->key = 'title';
+      $title->page = $this->page();
+      $title->value = $this->uid();
+    }
+    
+    return $title;
   }
 
   /**


### PR DESCRIPTION
Quick fix for 136. Wasn't sure if this should be done in the `$page->uid()` function or not.
