### PR TITLE
Title should return a field, not string, if title is not set.

### DIFF
--- a/core/page.php
+++ b/core/page.php
@@ -665,7 +665,15 @@ abstract class PageAbstract {
    */
   public function title() {
     $title = $this->content()->get('title');
-    return $title != '' ? $title : $this->uid();
+    
+    if (empty($title)) {
+      $title = new Field();
+      $title->key = 'title';
+      $title->page = $this;
+      $title->value = $this->uid();
+    }
+    
+    return $title;
   }
 
   /**


### PR DESCRIPTION
Take 2. This should fix issue 136 without the panel edits I did before.
