### PR TITLE
Don't overwrite a language specific content file with the default one

### DIFF
--- a/branches/multilang/page.php
+++ b/branches/multilang/page.php
@@ -160,12 +160,15 @@ class Page extends PageAbstract {
         $inventory['meta'][$file][$lang] = $content;
       } else {
 
-        if(is_null($lang)) {
-          $lang = f::extension($file);
-          if(empty($lang)) $lang = $defaultLang;
+        if (!is_null($lang)) {
+          $inventory['content'][$lang] = $content;
+        } else {
+          // Don't overwrite a language specific content file with the default one
+          if (!isset($inventory['content'][$defaultLang])) {
+            $inventory['content'][$defaultLang] = $content;
+          }
         }
 
-        $inventory['content'][$lang] = $content;
       }
 
       unset($inventory['content'][$key]);


### PR DESCRIPTION
Fixes https://github.com/getkirby/panel/issues/797

On a multilang setup (no matter if there are actually multiple languages or just one) the multilang page class (/kirby/branches/multilang/page.php) sets the content file for the default language to the "unextended" (page.txt) file if it exists, instead of picking the proper extension (page.langcode.txt). It works correctly for any non-default language.

This leads to seemingly disappearing edits: Edits are saved correctly to page.langcode.txt, but the panel and the site display page.txt instead. 
