### PR TITLE
Adds thumb options to preserve color (icc) profile and/or meta data (EXIF, IPTC) when using ImageMagick.

### DIFF
--- a/kirby/component/thumb.php
+++ b/kirby/component/thumb.php
@@ -39,6 +39,8 @@ class Thumb extends Component {
       'thumbs.bin'         => 'convert',
       'thumbs.interlace'   => false,
       'thumbs.quality'     => 90,
+      'thumbs.icc.profile' => false,
+      'thumbs.meta.data'   => false,
       'thumbs.memory'      => '128M',
       'thumbs.filename'    => false,
       'thumbs.destination' => function($thumb) use($self) {
@@ -69,6 +71,8 @@ class Thumb extends Component {
     generator::$defaults['driver']      = $this->kirby->option('thumbs.driver');
     generator::$defaults['bin']         = $this->kirby->option('thumbs.bin');
     generator::$defaults['quality']     = $this->kirby->option('thumbs.quality');
+    generator::$defaults['icc.profile'] = $this->kirby->option('thumbs.icc.profile');
+    generator::$defaults['meta.data']   = $this->kirby->option('thumbs.meta.data');
     generator::$defaults['interlace']   = $this->kirby->option('thumbs.interlace');
     generator::$defaults['memory']      = $this->kirby->option('thumbs.memory');
     generator::$defaults['destination'] = $this->kirby->option('thumbs.destination');
@@ -157,9 +161,11 @@ class Thumb extends Component {
   protected function options(Generator $thumb) {
 
     $keys = [
-      'blur'      => 'blur',
-      'grayscale' => 'bw',
-      'quality'   => 'q',
+      'blur'       => 'blur',
+      'grayscale'  => 'bw',
+      'quality'    => 'q',
+      'icc.profile'=> 'icc',
+      'meta.data'  => 'meta',
     ];
 
     $string = [];
@@ -181,6 +187,16 @@ class Thumb extends Component {
         } else {
           $string[] = $key . $value;
         }
+
+      } else if($key === 'icc') {
+
+          $value = a::get($thumb->options, 'meta.data');
+
+          if($value == false) {
+              $string[] = $key;
+          } else {
+              continue;
+          }
 
       } else if($value === true) {
         $string[] = $key;

--- a/vendor/getkirby/toolkit/lib/thumb.php
+++ b/vendor/getkirby/toolkit/lib/thumb.php
@@ -34,7 +34,7 @@ class Thumb extends Obj {
     'overwrite'   => false,
     'autoOrient'  => false,
     'interlace'   => false,
-	'icc.profile' => false,
+    'icc.profile' => false,
     'meta.data'   => false
   );
 

--- a/vendor/getkirby/toolkit/lib/thumb.php
+++ b/vendor/getkirby/toolkit/lib/thumb.php
@@ -33,7 +33,9 @@ class Thumb extends Obj {
     'grayscale'   => false,
     'overwrite'   => false,
     'autoOrient'  => false,
-    'interlace'   => false
+    'interlace'   => false,
+	'icc.profile' => false,
+    'meta.data'   => false
   );
 
   public $source      = null;
@@ -278,7 +280,10 @@ thumb::$drivers['im'] = function($thumb) {
 
   $command[] = isset($thumb->options['bin']) ? $thumb->options['bin'] : 'convert';
   $command[] = '"' . $thumb->source->root() . '"';
-  $command[] = '-strip';
+
+  if(!$thumb->options['icc.profile'] && !$thumb->options['meta.data']) {
+    $command[] = '-strip';
+  }
 
   if($thumb->options['interlace']) {
     $command[] = '-interlace line';
@@ -296,7 +301,11 @@ thumb::$drivers['im'] = function($thumb) {
     $command[] = '-auto-orient';
   }
 
-  $command[] = '-resize';
+  if($thumb->options['icc.profile'] && !$thumb->options['meta.data']) {
+    $command[] = '-thumbnail';
+  } else {
+    $command[] = '-resize';
+  }
 
   if($thumb->options['crop']) {
     if(empty($thumb->options['height'])) {


### PR DESCRIPTION
Now all major (desktop) browsers + iOS Safari honor color (icc) profiles and wide gamut screens become more common (inc. iPhone 7, iPad Pro, late 2016 MacBook Pro's, etc.), it makes sense to add and preserve a color profile in generated photo (thumb) files.

According to tests done by Arnoud Frich (see: http://www.color-management-guide.com/web-browser-color-management.html), it is best to always incorporated a ICC profile in (thumb) files, no matter what the profile is…

Though to maximize the chances to see photos correctly displayed on all screens in the world (office computers and tablets as well), it is recommend to incorporate **sRGB**.

If you love really nice images, and you have a (calibrated) wide gamut monitor, and know that most of your visitors (or intended audience) uses browser that can manage colors, than incorporate the **Adobe RGB 98** profile.

To make use of one of the added options of preserving color (icc) profile and/or all meta data, add one (or both) of the following lines to Kirby's config file:

```
c::set('thumbs.icc.profile', true);   // Preserve embedded color (or icc) profile in generated thumb only (any other profile and meta-data is removed); only works when thumb driver is set to 'im' (ImageMagick)
c::set('thumbs.meta.data', false);    // Preserve all embedded meta data in generated thumb (e.g. EXIF, IPTC, color profile, etc.); only works when thumb driver is set to 'im' (ImageMagick)
```

The meta data setting always trumps (overrules) the icc profile setting. When `thumbs.meta.data` is set to `true`, the color (icc) profile is also preserved (together with all the meta data, e.g. EXIF, IPTC, copyright notice, etc.), no matter if the `icc.profile` setting is set to `true` or `false`. Therefore when both settings are set to `true`, only the `meta` flag is added to the generated thumb file name.

File size is only marginally increased by adding the color profile (`thumbs.icc.profile` set to `true`), while preserving all meta data (`thumbs.meta.data` set to `true`) adds considerably to the total file size (some test show 30% more).