### PR TITLE
Account creation breaks

### DIFF
--- a/vendor/getkirby/toolkit/lib/r.php
+++ b/vendor/getkirby/toolkit/lib/r.php
@@ -298,7 +298,8 @@ class R {
    * @return boolean
    */
   public static function cli() {
-    return defined('STDIN') || (substr(PHP_SAPI, 0, 3) == 'cgi' && $term = getenv('TERM') && $term !== 'unknown');
+    $term = getenv('TERM');
+    return defined('STDIN') || (substr(PHP_SAPI, 0, 3) == 'cgi' && $term !== 'unknown');
   }
 
   /**


### PR DESCRIPTION
During account creation, the error message "Undefined variable: term" is displayed after attempting to create an account. The account file is actually created and looks correct, but subsequent logins fail "Invalid username/password".
This patch solves the issue.

(it is possible a check is needed for $term != false, but I'm not sure...