### PR TITLE
Redirect language-less urls to detected instead of default lang

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -361,7 +361,8 @@ class Kirby {
         'action'  => function($uri) use($site) {
           // first try to find a page with the given URI
           $page = page($uri);
-          if($page) return go($page);
+          $lang = $site->detectedLanguage()->code();
+          if($page) return go($page->url($lang));
 
           // the URI is not a valid page, redirect to the homepage of the default language
           return go($site->defaultLanguage()->url());


### PR DESCRIPTION
URLs without the language currently redirect to the default language but given that there is the language detection feature I think it would be better if the language-less URLs took advantage of this as well.