### PR TITLE
Added check for valid request methods in Kirby::launch()

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -715,8 +715,21 @@ class Kirby {
     // load all plugins
     $this->plugins();
 
+    // get all registered routes
+    $routes = $this->routes();
+
+    // check for a valid request method
+    // GET and HEAD are mandatory methods and must never be disabled
+    $allowed = array_unique(array_merge(array('GET', 'HEAD'), a::extract($routes, 'method')));
+    if(($key = array_search('ALL', $allowed)) !== false) unset($allowed[$key]);
+    if(!in_array(r::method(), $allowed)) {
+      header::status(405);
+      header('Allow: ' . implode(', ', $allowed));
+      exit(0);
+    }
+
     // start the router
-    $this->router = new Router($this->routes());
+    $this->router = new Router($routes);
     $this->route  = $this->router->run($this->path());
 
     // check for a valid route
@@ -725,7 +738,7 @@ class Kirby {
       header::type('json');
       die(json_encode(array(
         'status'  => 'error',
-        'message' => 'Invalid route or request method'
+        'message' => 'Invalid route'
       )));
     }
 


### PR DESCRIPTION
For example, requesting the homepage of a Kirby site via CONNECT or OPTIONS method gives back a 500 error.
There is no actual internal server error, so a 500 status code is incorrect and it is also not normal behaviour. These methods cannot be used, so the response status should be 405 (Method Not Allowed).

I have modified the launch() method in kirby.php to check for unused methods.
This is not fully waterproof, since you can still request other pages via DELETE for example if there is a route registered somewhere that uses the DELETE method.
But it is a start and it is IMHO better than the current implementation.