### PR TITLE
Added size check for thumbnails

### DIFF
--- a/vendor/getkirby/toolkit/lib/thumb.php
+++ b/vendor/getkirby/toolkit/lib/thumb.php
@@ -81,9 +81,15 @@ class Thumb extends Obj {
 
     }
 
-    // create the result object
-    $this->result = new Media($this->destination->root, $this->destination->url);
+    // create the result object for thumb
+    $new_thumb = new Media($this->destination->root, $this->destination->url);
 
+    // check if thumb is larger than original file before returning media object
+    if($this->isLarger($new_thumb)) {
+      $this->result = $this->source;
+    } else {
+      $this->result = $new_thumb;
+    }
   }
 
   /**
@@ -190,6 +196,24 @@ class Thumb extends Obj {
     // if the thumb already exists and the source hasn't been updated
     // we don't need to generate a new thumbnail
     if(file_exists($this->destination->root) && f::modified($this->destination->root) >= $this->source->modified()) return true;
+
+    return false;
+
+  }
+
+  /**
+   * Checks if the thumbnail is larger than the original file
+   *
+   * @return boolean
+   */
+  public function isLarger($new_thumb) {
+
+    // if the thumb is not visually different to its source
+    // but is larger, better use the original image
+    if($new_thumb->size() >= $this->source->size()    &&
+      $this->options['blur']    == false              &&
+      $this->options['grayscale']    == false         &&
+      $this->options['crop'] == false) return true;
 
     return false;
 


### PR DESCRIPTION
Since neither gd nor im do proper image optimization sometimes generated thumbnails can be larger (in terms of filesize) than their original images. This is especially true when it comes to animated gifs as source images.

Since a smaller filesize is the main motivation to create a thumbnail this is against most users interest.

This commit adds a little function to the thumb library which checks if a thumbnail is larger than its original image. If this is true (and there are no changes to be done, like cropping, blurring etc.) it returns the original file instead.

